### PR TITLE
Remove AXI_ERROR_RESP_G

### DIFF
--- a/firmware/common/7Series/rtl/AxiXadcWrapper.vhd
+++ b/firmware/common/7Series/rtl/AxiXadcWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiXadcWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-01-30
--- Last update: 2017-03-17
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -23,8 +23,7 @@ use work.AxiLitePkg.all;
 
 entity AxiXadcWrapper is
    generic (
-      TPD_G            : time            := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0) := AXI_RESP_DECERR_C);
+      TPD_G            : time            := 1 ns);
    port (
       axiClk : in sl;
       axiRst : in sl;

--- a/firmware/common/core/rtl/AppCore.vhd
+++ b/firmware/common/core/rtl/AppCore.vhd
@@ -2,7 +2,7 @@
 -- File       : AppCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-02-15
--- Last update: 2017-03-17
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description:
 -------------------------------------------------------------------------------
@@ -29,7 +29,6 @@ entity AppCore is
       XIL_DEVICE_G     : string           := "7SERIES";
       APP_TYPE_G       : string           := "ETH";
       AXIS_SIZE_G      : positive         := 1;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
       MAC_ADDR_G       : slv(47 downto 0) := x"010300564400";  -- 00:44:56:00:03:01 (ETH only)
       IP_ADDR_G        : slv(31 downto 0) := x"0A02A8C0";  -- 192.168.2.10 (ETH only)
       DHCP_G           : boolean          := true;
@@ -157,8 +156,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          BUILD_INFO_G     => BUILD_INFO_G,
-         XIL_DEVICE_G     => XIL_DEVICE_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         XIL_DEVICE_G     => XIL_DEVICE_G)
       port map (
          -- Clock and Reset
          clk             => clk,

--- a/firmware/targets/XilinxAC701DevBoard/Ac701GigE/hdl/Ac701GigE.vhd
+++ b/firmware/targets/XilinxAC701DevBoard/Ac701GigE/hdl/Ac701GigE.vhd
@@ -2,7 +2,7 @@
 -- File       : Ac701GigE.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-02-02
--- Last update: 2017-02-16
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Example using 1000BASE-SX Protocol
 -------------------------------------------------------------------------------
@@ -81,8 +81,6 @@ begin
          DIVCLK_DIVIDE_G    => 1,
          CLKFBOUT_MULT_F_G  => 8.0,
          CLKOUT0_DIVIDE_F_G => 8.0,
-         -- AXI-Lite Configurations
-         AXI_ERROR_RESP_G   => AXI_RESP_SLVERR_C,
          -- AXI Streaming Configurations
          AXIS_CONFIG_G      => (others => EMAC_AXIS_CONFIG_C))
       port map (

--- a/firmware/targets/XilinxKC705DevBoard/Kc705GigE/hdl/Kc705GigE.vhd
+++ b/firmware/targets/XilinxKC705DevBoard/Kc705GigE/hdl/Kc705GigE.vhd
@@ -2,7 +2,7 @@
 -- File       : Kc705GigE.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-02-02
--- Last update: 2016-05-11
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Example using 1000BASE-SX Protocol
 -------------------------------------------------------------------------------
@@ -78,8 +78,6 @@ begin
          DIVCLK_DIVIDE_G    => 1,
          CLKFBOUT_MULT_F_G  => 8.0,
          CLKOUT0_DIVIDE_F_G => 8.0,
-         -- AXI-Lite Configurations
-         AXI_ERROR_RESP_G   => AXI_RESP_SLVERR_C,
          -- AXI Streaming Configurations
          AXIS_CONFIG_G      => (others => EMAC_AXIS_CONFIG_C))
       port map (


### PR DESCRIPTION
Updated for compatibility with SURF v1.7.1 - slaclab/surf#147.
 * Removed all AXI_ERROR_RESP_G generics
 * Removed all AxiLiteEmpty instances