### PR TITLE
YAML fixes for interleaved RSSI; fixed some critical warnings

### DIFF
--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/Makefile
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/Makefile
@@ -12,8 +12,9 @@ export PRJ_PART = XCKU040-FFVA1156-2-E
 
 # Whether to use the on-board PHY (connected to the RJ-45 jack)
 # or an SFP module for ethernet connectivity.
-# Must be true or false
-export USE_RJ45_ETH = false
+# Must be 1 or 0
+export USE_RJ45_ETH = 0
+
 export INCLUDE_ETH_SGMII_LVDS = 1
 
 # Using a non-standard target directory structure, 

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/README.ethernet
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/README.ethernet
@@ -23,7 +23,7 @@ By default, option 1) is enabled. If you want to build the
 example for option 2) then you must change the corresponding
 line in the Makefile to
 
-export USE_RJ45_ETH=true
+export USE_RJ45_ETH=1
 
 For 2. The ethernet link status is reported by LEDs 5..7:
        (for the connections of other LEDs consult the vhdl)

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE.vhd
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE.vhd
@@ -202,7 +202,7 @@ begin
 
       extPhyReady <= rstCnt(23);
 
-      extPhyRstN <= ite((unsigned(rstCnt(22 downto 20)) > 3) and (extPhyReady = '0'), '0', '1');
+      extPhyRstN <= ite((unsigned(rstCnt(22 downto 20)) > 2) and (extPhyReady = '0'), '0', '1');
 
       -- The MDIO controller which talks to the external PHY must be held
       -- in reset until extPhyReady; it works in a different clock domain...

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE.vhd
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE.vhd
@@ -49,13 +49,6 @@ entity Kcu105GigE is
       ethRxN     : in    sl;
       ethTxP     : out   sl;
       ethTxN     : out   sl;
-      -- SGMII (ext. PHY) ETH
-      sgmiiClkP  : in    sl;
-      sgmiiClkN  : in    sl;
-      sgmiiRxP   : in    sl;
-      sgmiiRxN   : in    sl;
-      sgmiiTxP   : out   sl;
-      sgmiiTxN   : out   sl;
       -- ETH external PHY pins
       phyMdc     : out   sl;
       phyMdio    : inout sl;
@@ -68,8 +61,10 @@ end Kcu105GigE;
 
 architecture top_level of Kcu105GigE is
 
-   constant AXIS_SIZE_C : positive         := 1;
-   constant RST_DEL_C   : slv(23 downto 0) := X"5FFFFF";  -- 2*10ms @ 300MHz
+   constant AXIS_SIZE_C       : positive         := 1;
+   constant ETH_AXIS_CONFIG_C : AxiStreamConfigArray(3 downto 0) := (others => EMAC_AXIS_CONFIG_C);
+
+   constant RST_DEL_C         : slv(23 downto 0) := X"5FFFFF";  -- 2*10ms @ 300MHz
 
    signal txMasters : AxiStreamMasterArray(AXIS_SIZE_C-1 downto 0);
    signal txSlaves  : AxiStreamSlaveArray(AXIS_SIZE_C-1 downto 0);
@@ -146,13 +141,13 @@ begin
             CLKFBOUT_MULT_F_G  => 32.0,  -- 1 GHz = (32 x 31.25 MHz)
             CLKOUT0_DIVIDE_F_G => 8.0,   -- 125 MHz = (1.0 GHz/8)
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G      => (others => EMAC_AXIS_CONFIG_C))
+            AXIS_CONFIG_G      => ETH_AXIS_CONFIG_C)
          port map (
             -- Local Configurations
-            localMac     => (others => MAC_ADDR_INIT_C),
+            localMac(0)  => MAC_ADDR_INIT_C,
             -- Streaming DMA Interface
-            dmaClk       => (others => clk),
-            dmaRst       => (others => rst),
+            dmaClk(0)    => clk,
+            dmaRst(0)    => rst,
             dmaIbMasters => rxMasters,
             dmaIbSlaves  => rxSlaves,
             dmaObMasters => txMasters,
@@ -275,13 +270,13 @@ begin
             DIVCLK_DIVIDE_G   => 2,     -- 312.5 MHz
             CLKFBOUT_MULT_F_G => 2.0,   -- VCO: 625 MHz
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G     => (others => EMAC_AXIS_CONFIG_C))
+            AXIS_CONFIG_G     => ETH_AXIS_CONFIG_C)
          port map (
             -- Local Configurations
-            localMac           => (others => MAC_ADDR_INIT_C),
+            localMac(0)        => MAC_ADDR_INIT_C,
             -- Streaming DMA Interface
-            dmaClk             => (others => clk),
-            dmaRst             => (others => rst),
+            dmaClk(0)          => clk,
+            dmaRst(0)          => rst,
             dmaIbMasters       => rxMasters,
             dmaIbSlaves        => rxSlaves,
             dmaObMasters       => txMasters,
@@ -296,13 +291,13 @@ begin
             speed_is_100(0)    => speed100,
 
             -- MGT Clock Port
-            sgmiiClkP   => sgmiiClkP,
-            sgmiiClkN   => sgmiiClkN,
+            sgmiiClkP   => ethClkP,
+            sgmiiClkN   => ethClkN,
             -- MGT Ports
-            sgmiiTxP(0) => sgmiiTxP,
-            sgmiiTxN(0) => sgmiiTxN,
-            sgmiiRxP(0) => sgmiiRxP,
-            sgmiiRxN(0) => sgmiiRxN);
+            sgmiiTxP(0) => ethTxP,
+            sgmiiTxN(0) => ethTxN,
+            sgmiiRxP(0) => ethRxP,
+            sgmiiRxN(0) => ethRxN);
 
    end generate GEN_SGMII;
 

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE.vhd
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE.vhd
@@ -33,7 +33,7 @@ entity Kcu105GigE is
       BUILD_INFO_G  : BuildInfoType;
       SIM_SPEEDUP_G : boolean := false;
       SIMULATION_G  : boolean := false;
-      SGMII_ETH_G   : boolean := false);
+      SGMII_ETH_G   : integer := 0);
    port (
       -- Misc. IOs
       extRst     : in    sl;
@@ -129,8 +129,7 @@ begin
          syncRst  => sysRst300
          );
 
-
-   GEN_GTH : if (not SGMII_ETH_G) generate
+   GEN_GTH : if (SGMII_ETH_G = 0) generate
 
       ---------------------
       -- 1 GigE XAUI Module
@@ -177,7 +176,7 @@ begin
 
    end generate GEN_GTH;
 
-   GEN_SGMII : if (SGMII_ETH_G) generate
+   GEN_SGMII : if (SGMII_ETH_G /= 0) generate
 
       signal rstCnt     : slv(23 downto 0) := RST_DEL_C;
       signal phyInitRst : sl;

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE_Sgmii.xdc
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/hdl/Kcu105GigE_Sgmii.xdc
@@ -10,18 +10,18 @@
 # I/O Port Mapping
 
 # SGMII/Ext. PHY
-set_property PACKAGE_PIN P25 [get_ports sgmiiRxN]
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports sgmiiRxN]
-set_property PACKAGE_PIN P24 [get_ports sgmiiRxP]
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports sgmiiRxP]
-set_property PACKAGE_PIN M24 [get_ports sgmiiTxN]
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports sgmiiTxN]
-set_property PACKAGE_PIN N24 [get_ports sgmiiTxP]
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports sgmiiTxP]
-set_property PACKAGE_PIN N26 [get_ports sgmiiClkN]
-set_property IOSTANDARD LVDS_25 [get_ports sgmiiClkN]
-set_property PACKAGE_PIN P26 [get_ports sgmiiClkP]
-set_property IOSTANDARD LVDS_25 [get_ports sgmiiClkP]
+set_property PACKAGE_PIN P25 [get_ports ethRxN]
+set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports ethRxN]
+set_property PACKAGE_PIN P24 [get_ports ethRxP]
+set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports ethRxP]
+set_property PACKAGE_PIN M24 [get_ports ethTxN]
+set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports ethTxN]
+set_property PACKAGE_PIN N24 [get_ports ethTxP]
+set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports ethTxP]
+set_property PACKAGE_PIN N26 [get_ports ethClkN]
+set_property IOSTANDARD LVDS_25 [get_ports ethClkN]
+set_property PACKAGE_PIN P26 [get_ports ethClkP]
+set_property IOSTANDARD LVDS_25 [get_ports ethClkP]
 
 # Placement - put SGMII ETH close in clock region of the 625MHz clock;
 #             otherwise it is difficult to meet timing.
@@ -31,6 +31,6 @@ resize_pblock       [get_pblocks SGMII_ETH_BLK] -add {CLOCKREGION_X2Y1:CLOCKREGI
 
 
 # Timing Constraints 
-create_clock -name lvdsClkP  -period 1.600 [get_ports {sgmiiClkP}]
+create_clock -name lvdsClkP  -period 1.600 [get_ports {ethClkP}]
 
 create_generated_clock -name ethClk125MHz  [get_pins {GEN_SGMII.U_1GigE/U_MMCM/CLKOUT0}] 

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/ruckus.tcl
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/ruckus.tcl
@@ -7,7 +7,7 @@ loadRuckusTcl $::env(PROJ_DIR)/../../../
 # Load local source Code and constraints
 loadSource      -dir "$::DIR_PATH/hdl/"
 
-if { "$::env(USE_RJ45_ETH)" == "true" } {
+if { "$::env(USE_RJ45_ETH)" != 0 } {
    loadConstraints -path "$::DIR_PATH/hdl/Kcu105GigE_Sgmii.xdc"
 } else {
    loadConstraints -path "$::DIR_PATH/hdl/Kcu105GigE_Gth.xdc"

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/vivado/pre_synthesis.tcl
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/vivado/pre_synthesis.tcl
@@ -1,1 +1,0 @@
-# set_property generic [ list "SGMII_ETH_G=$::env(USE_RJ45_ETH)" [get_property generic [current_fileset]] ] [current_fileset]

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/vivado/sources.tcl
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/vivado/sources.tcl
@@ -1,0 +1,7 @@
+set genericArgList [get_property generic [current_fileset]]
+
+if { "$::env(USE_RJ45_ETH)" != 0 } {
+   lappend genericArgList "SGMII_ETH_G=1"
+}
+
+set_property generic ${genericArgList} -objects [current_fileset]

--- a/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/yaml/000TopLevel.yaml
+++ b/firmware/targets/XilinxKCU105DevBoard/Kcu105GigE/yaml/000TopLevel.yaml
@@ -92,7 +92,7 @@ stream: &stream
       numRxThreads: 2
     RSSI: yes
     depack:
-      useDepack: yes
+      protocolVersion: DEPACKETIZER_V2
     TDESTMux:
       TDEST: 0x80
       stripHeader: yes
@@ -115,6 +115,7 @@ NetIODev:
            port: 8192
          RSSI:
          depack:
+           protocolVersion: DEPACKETIZER_V2
          TDESTMux:
            TDEST: 0
      Stream0:


### PR DESCRIPTION
- The RSSI core has previously been switched to interleaved RSSI mode (depacketizer V2). This patch updates the YAML accordingly.

- several critical warnings have been fixed.

- TCL and Makefile fixes enable control over the choice of ethernet port (GTH/SFP vs. LVDS/RJ45) from a single Makefile variable (USE_RJ45_ETH). The variable gets passed to and evaluated by TCL in order to pick the proper constraints and set a top-level generic.